### PR TITLE
some suggested adjustments for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-versions: [ 3.8, 3.9, 3.10 ]
+        # initially, just one python version while fixing pending tests
+        python-versions: [ 3.9 ]  #  [ 3.8, 3.9, 3.10 ]
         os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
 
@@ -24,6 +25,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update && sudo apt-get upgrade -y
+          sudo apt-get install libsndfile1
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-versions: [ 3.8, 3.9, 3.10 ]
+        os: [ ubuntu-20.04 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-versions }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run unit tests
+        run:
+          PYPAM_TEST_NO_PLOTS= python -m unittest

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+# Basic support for unit tests.
+
+from os import getenv
+import unittest
+
+
+def with_plots() -> bool:
+    return getenv('PYPAM_TEST_NO_PLOTS') is None
+
+
+def skip_unless_with_plots():
+    def decorator(test_item):
+        if with_plots():
+            return test_item
+        else:
+            reason = 'PYPAM_TEST_NO_PLOTS is set'
+            return unittest.skip(reason)(test_item)
+    return decorator
+

--- a/tests/test_acoustic_file.py
+++ b/tests/test_acoustic_file.py
@@ -1,7 +1,7 @@
 import unittest
-
 from pypam.acoustic_file import AcuFile
 import pyhydrophone as pyhy
+from tests import skip_unless_with_plots
 
 # Another hydrophone
 st = pyhy.SoundTrap('SoundTrap', 'ST600HF', '6716')
@@ -17,8 +17,9 @@ soundtrap = pyhy.soundtrap.SoundTrap(name=name, model=model, serial_number=seria
 
 class TestAcuFile(unittest.TestCase):
     def setUp(self) -> None:
-        self.acu_file = AcuFile('test_data/67416073.210610033655.wav', soundtrap, 1)
+        self.acu_file = AcuFile('tests/test_data/67416073.210610033655.wav', soundtrap, 1)
 
+    @skip_unless_with_plots()
     def test_plots(self):
         self.acu_file.plot_power_spectrum()
 

--- a/tests/test_acoustic_survey.py
+++ b/tests/test_acoustic_survey.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 
 from pypam.acoustic_survey import ASA
 import pyhydrophone as pyhy
+from tests import skip_unless_with_plots, with_plots
 
 
 # Data information
@@ -36,7 +37,7 @@ zipped_files = False
 
 class TestASA(unittest.TestCase):
     def setUp(self) -> None:
-        self.asa = ASA(hydrophone=soundtrap, folder_path='./test_data', binsize=binsize, nfft=nfft, timezone='UTC',
+        self.asa = ASA(hydrophone=soundtrap, folder_path='tests/test_data', binsize=binsize, nfft=nfft, timezone='UTC',
                        include_dirs=include_dirs, zipped=zipped_files, dc_subtract=dc_subtract)
 
     def test_timestamp_array(self):
@@ -44,7 +45,7 @@ class TestASA(unittest.TestCase):
 
     def test_nmf(self):
         ds = self.asa.source_separation(window_time=1.0, n_sources=15, save_path=None, verbose=False)
-        self.asa = ASA(hydrophone=soundtrap, folder_path='./../data', binsize=binsize, nfft=nfft, utc=True,
+        self.asa = ASA(hydrophone=soundtrap, folder_path='./../data', binsize=binsize, nfft=nfft, timezone='UTC',
                        include_dirs=include_dirs, zipped=zipped_files)
 
     def test_features(self):
@@ -61,6 +62,7 @@ class TestASA(unittest.TestCase):
         self.asa.apply_to_all('plot_spectrogram')
         self.asa.apply_to_all('plot_psd')
 
+    @skip_unless_with_plots()
     def test_spd(self):
         h_db = 1
         percentiles = [1, 10, 50, 90, 95]
@@ -69,6 +71,7 @@ class TestASA(unittest.TestCase):
         self.asa.plot_spd(db=True, h=h_db, percentiles=percentiles, min_val=min_val, max_val=max_val)
 
     def test_detect_piling_events(self):
+        verbose = with_plots()
         min_separation = 1
         max_duration = 0.2
         threshold = 20
@@ -76,30 +79,36 @@ class TestASA(unittest.TestCase):
         detection_band = [500, 1000]
 
         self.asa.detect_piling_events(max_duration=max_duration, min_separation=min_separation,
-                                      threshold=threshold, dt=dt, verbose=True, method='snr',
+                                      threshold=threshold, dt=dt, verbose=verbose, method='snr',
                                       save_path=None, detection_band=detection_band, analysis_band=None)
 
     def test_detect_ship_events(self):
         # just a smoke test to check if the function can run without errors
         self.asa.detect_ship_events(0.1, 0.5)
 
+    @skip_unless_with_plots()
     def test_plot_spd(self):
         self.asa.plot_spd(percentiles=[1, 5, 10, 50, 90, 95, 99])
 
+    @skip_unless_with_plots()
     def test_plot_mean_spectrum(self):
         self.asa.plot_mean_power_spectrum()
         self.asa.plot_mean_psd(percentiles=[10, 50, 90])
 
+    @skip_unless_with_plots()
     def test_plot_ltsa(self):
         self.asa.plot_power_ltsa(percentiles=[1, 5, 10, 50, 90, 95, 99])
         self.asa.plot_psd_ltsa()
 
+    @skip_unless_with_plots()
     def test_plot_rms_evolution(self):
         self.asa.plot_rms_evolution()
 
+    @skip_unless_with_plots()
     def test_plot_daily_patterns(self):
         self.asa.plot_rms_daily_patterns()
 
+    @skip_unless_with_plots()
     def test_millidecade_bands(self):
         # Set the frequency resolution to 1 Hz and the duration of 1 second
         milli_psd = self.asa.hybrid_millidecade_bands(db=True, method='spectrum', band=[0, 4000], percentiles=None)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,7 +6,7 @@ import pyhydrophone as pyhy
 
 
 # Acoustic Data
-summary_path = pathlib.Path('./test_data/data_summary.csv')
+summary_path = pathlib.Path('tests/test_data/data_summary.csv')
 include_dirs = False
 
 # Output folder

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import xarray
+from os import getenv
 import matplotlib.pyplot as plt
 import scipy
 
@@ -13,7 +14,7 @@ test_freqs = [400, fs / 4]
 samples = fs
 noise_amp = 100
 signal_amp = 100
-data = pd.read_csv('./test_data/signal_data.csv', header=None)[0].values
+data = pd.read_csv('tests/test_data/signal_data.csv', header=None)[0].values
 t = np.linspace(0, 1 - 1 / fs, samples)
 phase = 2 * np.pi * t
 for test_freq in test_freqs:
@@ -26,7 +27,7 @@ nfft = fs
 class TestMillidecades(unittest.TestCase):
     def test_get_millidecade_bands(self):
         bands_limits, bands_c = utils.get_hybrid_millidecade_limits(band=[0, fs/2], nfft=nfft)
-        mdec_bands_test = pd.read_csv('./test_data/mdec_bands_test.csv', header=None)
+        mdec_bands_test = pd.read_csv('tests/test_data/mdec_bands_test.csv', header=None)
         assert ((mdec_bands_test.iloc[:, 0] - bands_limits[:-1]) > 5e-5).sum() == 0
         assert ((mdec_bands_test.iloc[:, 2] - bands_limits[1:]) > 5e-5).sum() == 0
         assert ((mdec_bands_test.iloc[:, 1] - bands_c) > 5e-5).sum() == 0
@@ -45,11 +46,10 @@ class TestMillidecades(unittest.TestCase):
         fbands = scipy.fft.rfftfreq(nfft, 1/fs)
 
         # Load the spectrum used for MANTA
-        spectra_manta = pd.read_csv('./test_data/spectra.csv', header=None)
+        spectra_manta = pd.read_csv('tests/test_data/spectra.csv', header=None)
 
         # Check if they are the same
         assert (abs(spectra_manta[0].values - spectra) > 1e-5).sum() == 0
-        print('Spectrum is the same with a 1e-5 precision')
 
         # Convert the spectra to a datarray
         psd_da = xarray.DataArray([spectra], coords={'id': [0], 'frequency': fbands}, dims=['id', 'frequency'])
@@ -57,22 +57,22 @@ class TestMillidecades(unittest.TestCase):
         milli_psd = utils.psd_ds_to_bands(psd_da, bands_limits, bands_c, fft_bin_width=fs/nfft, db=False)
 
         # Read MANTA's output
-        mdec_power_test = pd.read_csv('./test_data/mdec_power_test.csv')
+        mdec_power_test = pd.read_csv('tests/test_data/mdec_power_test.csv')
 
-        # Plot the two outputs for comparison
-        fig, ax = plt.subplots()
-        ax.plot(milli_psd.frequency_bins, mdec_power_test['sum'], label='MANTA')
-        plt.legend()
-        plt.show()
+        if getenv('PYPAM_TEST_NO_PLOTS') is None:
+            # Plot the two outputs for comparison
+            fig, ax = plt.subplots()
+            ax.plot(milli_psd.frequency_bins, mdec_power_test['sum'], label='MANTA')
+            plt.legend()
+            plt.show()
 
-        fig, ax = plt.subplots()
-        milli_psd.plot(ax=ax, label='pypam')
-        plt.legend()
-        plt.show()
+            fig, ax = plt.subplots()
+            milli_psd.plot(ax=ax, label='pypam')
+            plt.legend()
+            plt.show()
 
         # Check if the results are the same
         assert ((mdec_power_test['sum'] - milli_psd.sel(id=0).values).abs() > 1e-5).sum() == 0
-        print('Results are the same with a 1e-5 precision')
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,9 @@ import unittest
 import numpy as np
 import pandas as pd
 import xarray
-from os import getenv
 import matplotlib.pyplot as plt
 import scipy
+from tests import with_plots
 
 import pypam.utils as utils
 
@@ -59,7 +59,7 @@ class TestMillidecades(unittest.TestCase):
         # Read MANTA's output
         mdec_power_test = pd.read_csv('tests/test_data/mdec_power_test.csv')
 
-        if getenv('PYPAM_TEST_NO_PLOTS') is None:
+        if with_plots():
             # Plot the two outputs for comparison
             fig, ax = plt.subplots()
             ax.plot(milli_psd.frequency_bins, mdec_power_test['sum'], label='MANTA')


### PR DESCRIPTION
Hi @cparcerisas - In a first commit here, I'm just using test_utils as a basis for suggesting some adjustments and possible next steps that could be considered also for other units tests.  (PR mainly for discussion purposes at this point ; ) 

- In general, one would expect the unit tests to be run from the root directory. Of course, this is not forced at all, but that's what one would typically find out there for projects regardless of concrete language. So, I adjusted the path to the relevant files here to start from `tests/`.

- As unit tests per se, also having some plots generated makes a bit difficult if wishing to also be able to run such tests in a CI server (e.g, via a GitHub Actions workflow, which would be nice to incorporate in this project). To reduce changes at this point, the plots in this particular test continue to be generated by default, but one can define the `PYPAM_TEST_NO_PLOTS` environment variable (value doesn't matter) to skip the plotting part.

With the adjustments above, one can then run this particular test, including the plots, from the root as follows:

```shell
$ python -m unittest tests.test_utils
```

> or with `$ python tests/test_utils.py` given the `__main__` section in the file.

And, without generating the plots:

```shell
$ PYPAM_TEST_NO_PLOTS= python -m unittest tests.test_utils
..
----------------------------------------------------------------------
Ran 2 tests in 0.518s

OK
```

What do you think?