### PR TITLE
add pip freeze to see installed dep versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt-get install libsndfile1
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+          python -m pip freeze
 
       - name: Run unit tests
         run:


### PR DESCRIPTION
Hi @cparcerisas -- 
As we discussed, this is intended to help diagnose potential issues on CI.