### PR TITLE
adjust condition for plotting or not in test_source_separation

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -2,7 +2,7 @@ import unittest
 import pypam.signal as sig
 import pypam.nmf as nmf
 import numpy as np
-from tests import skip_unless_with_plots
+from tests import skip_unless_with_plots, with_plots
 import matplotlib.pyplot as plt
 
 
@@ -39,6 +39,6 @@ class TestSignal(unittest.TestCase):
         separator = nmf.NMF(window_time=0.1, rank=15)
         s = sig.Signal(self.data, fs=fs)
         s.set_band(None)
-        separation_ds = separator(s, verbose=True)
+        separation_ds = separator(s, verbose=with_plots())
         reconstructed_sources = separator.reconstruct_sources(separation_ds)
         separator.return_filtered_signal(s, reconstructed_sources['C_tf'])


### PR DESCRIPTION
A simple fix, so plots are not attempted, particularly convenient in CI as it avoids the unnecessary overhead there (even though the latex dependency has helped with the otherwise failing plotting in the past).