### PR TITLE
`make test` (not `make tests`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Run unit tests
         run:
-          PYPAM_TEST_NO_PLOTS= make tests
+          PYPAM_TEST_NO_PLOTS= make test


### PR DESCRIPTION
fixes #44 , that is the ci workflow per se.

Note: some of tests themselves are failing. I noted this locally upon syncing my clone and was surprised to see CI green on GitHub.