### PR TITLE
Remove get_pypam_version

### DIFF
--- a/pypam/__init__.py
+++ b/pypam/__init__.py
@@ -1,17 +1,5 @@
-"""
-Main PyPAM module.
-"""
-__version__ = "0.3.0"
-
 from pypam.dataset import DataSet
 from pypam.acoustic_survey import ASA
 from pypam.acoustic_file import AcuFile
 from pypam.signal import Signal
 from pypam.detection import Detection
-
-
-def get_pypam_version():
-    """
-    Get the version of the pypam package.
-    """
-    return __version__


### PR DESCRIPTION
Client code can use something like:

        import importlib.metadata

        return importlib.metadata.version("lifewatch-pypam")


@cparcerisas - sorry for the little "noise" with this version thing. As it is not really used/needed within pypam itself, client code (like pbp) can simply use a mechanism like the importlib above to get such version. So, I'm "reverting" (removing) that function. Thanks.