### PR TITLE
Path related fixes to impulsive-metrics related testing in previous PR

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -129,7 +129,7 @@ def test_energy_window():
     tol = 7 # us
     plot=True
     def load_and_window_data(filename, plot=False):
-        raw_data = np.loadtxt(f'{test_dir}\\test_data\\impulsive_data\\{filename}',delimiter=',')
+        raw_data = np.loadtxt(f'{test_dir}/test_data/impulsive_data/{filename}',delimiter=',')
         t, P = raw_data[:,0], raw_data[:,1]
         t = t+np.abs(np.min(t))
         t_interp = np.linspace(0,np.max(t),num=500)


### PR DESCRIPTION
The previous pull request related to impulsive metrics was passing the unit test on windows, but in the CI was failing due to multiple instances of FileNotFoundError.  This PR is an attempt to resolve this, and only includes edits to tests authored for the previous PR relating to impulsive-metrics. The branch is passing the CI unit test on the fork (and now here).  Thanks and apologies for the multiple PRs for these features. 